### PR TITLE
fix: use PAT for release-please to allow PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
               id: release
               with:
                   release-type: node
+                  token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
     package:
         name: Package & Upload App


### PR DESCRIPTION
## Problem

The Release workflow on `main` is failing because GitHub Actions is not permitted to create pull requests using the default `GITHUB_TOKEN`.

Failing run: https://github.com/jkantarek/rc-chat-reminders/actions/runs/25283260250

Error:
```
release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

## Fix

Pass a fine-grained PAT (`RELEASE_PLEASE_TOKEN`) to the `release-please-action` step. The PAT has `Contents: read/write` and `Pull requests: read/write` scopes scoped to this repository, which is sufficient for release-please to push commits and open its release PR.