### PR TITLE
fix: add environment: release to release-please job for secret access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     release-please:
         name: Release Please
         runs-on: ubuntu-latest
+        environment: release
         outputs:
             release_created: ${{ steps.release.outputs.release_created }}
             tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Problem

The `RELEASE_PLEASE_TOKEN` secret is scoped to the `release` environment, but the `release-please` job didn't declare `environment: release`, so the secret resolved to an empty string.

This caused:
```
Error: release-please failed: Input required and not supplied: token
```

## Fix

Add `environment: release` to the `release-please` job so it has access to the environment-scoped secret.