### PR TITLE
Fix release packaging build on clean CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Tests + Coverage
         run: pnpm test:coverage
+
+      - name: Package private app
+        run: pnpm rc:package

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pnpm test          # Run unit tests + inline doctests
 pnpm typecheck     # TypeScript type-check (zero errors)
 pnpm lint          # ESLint (zero warnings)
 pnpm format:check  # Prettier formatting check
+pnpm rc:package    # Verify the private app package builds cleanly
 ```
 
 ### Building and deploying
@@ -95,6 +96,7 @@ pnpm typecheck      # Zero TypeScript errors
 pnpm lint           # Zero ESLint warnings
 pnpm format:check   # All files formatted
 pnpm test:coverage  # All tests pass, ≥98% coverage
+pnpm rc:package     # Private app zip builds successfully
 ```
 
 Enforced by a pre-commit hook (`script/lint --staged`) and CI (`.github/workflows/ci.yml`).

--- a/script/ci
+++ b/script/ci
@@ -20,6 +20,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   echo "  2. ESLint zero warnings    pnpm lint"
   echo "  3. Prettier format check   pnpm format:check"
   echo "  4. Tests + coverage        pnpm test:coverage  (must be >=98%)"
+  echo "  5. Package private app     pnpm rc:package"
   echo ""
   echo "Options:"
   echo "  -h, --help   Show this help message"
@@ -58,6 +59,7 @@ run_gate "TypeScript type check" "pnpm typecheck"
 run_gate "ESLint (zero warnings)"  "pnpm lint"
 run_gate "Prettier format check"   "pnpm format:check"
 run_gate "Tests + coverage (>=98%)" "pnpm test:coverage"
+run_gate "Package private app" "pnpm rc:package"
 
 echo ""
 if [ ${#FAILED[@]} -eq 0 ]; then

--- a/script/rc-package
+++ b/script/rc-package
@@ -32,6 +32,11 @@ json_field() {
   node -p "JSON.parse(require('fs').readFileSync('app.json', 'utf8')).${field} ?? ''"
 }
 
+package_field() {
+  local field="$1"
+  node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).${field} ?? ''"
+}
+
 copy_file_into_package() {
   local rel="$1"
   mkdir -p "$PACKAGE_DIR/$(dirname "$rel")"
@@ -50,10 +55,11 @@ cleanup() {
 trap cleanup EXIT
 
 [[ -f app.json ]] || fail "app.json is required"
+[[ -f package.json ]] || fail "package.json is required"
 [[ -d src ]] || fail "src/ directory is required"
 
 APP_NAME_SLUG="$(json_field 'nameSlug')"
-APP_VERSION="$(json_field 'version')"
+APP_VERSION="$(package_field 'version')"
 APP_CLASS_FILE="$(json_field 'classFile')"
 APP_ICON_FILE="$(json_field 'iconFile')"
 APP_ASSETS_FOLDER="$(json_field 'assetsFolder')"
@@ -109,6 +115,9 @@ COMPILED_MAIN="$BUILD_DIR/${APP_CLASS_FILE%.ts}.js"
 [[ -f "$COMPILED_MAIN" ]] || fail "compiled classFile '$COMPILED_MAIN' was not produced"
 
 copy_file_into_package "app.json"
+
+node -e "const fs=require('fs'); const file=process.argv[1]; const version=process.argv[2]; const info=JSON.parse(fs.readFileSync(file,'utf8')); info.version=version; fs.writeFileSync(file, JSON.stringify(info, null, 2) + '\n');" \
+  "$PACKAGE_DIR/app.json" "$APP_VERSION"
 
 if [[ -n "$APP_ICON_FILE" ]]; then
   copy_file_into_package "$APP_ICON_FILE"

--- a/tsconfig.rc.json
+++ b/tsconfig.rc.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2017",
     "module": "commonjs",
-    "lib": ["ES6"],
+    "lib": ["ES2017"],
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,


### PR DESCRIPTION
## Summary

- update the RC packaging TypeScript target/lib so the staged app build works on clean GitHub runners
- stamp the packaged zip and packaged `app.json` version from `package.json` so release assets match the release version
- add `pnpm rc:package` to normal CI and the local CI script so packaging failures are caught before release time

## Testing

- `pnpm rc:package`
- `script/ci`
- `git push` (pre-push hook ran `pnpm test:coverage`)

Closes #9
