### PR TITLE
Fix draft release tag creation for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,11 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
+      "component": "rc-chat-reminders",
       "draft": true,
+      "force-tag-creation": true,
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
       "release-type": "node"
     }
   }


### PR DESCRIPTION
## Summary

- force tag creation for draft `release-please` releases so the next run can reliably detect the latest release
- make tag naming explicit by locking the component-prefixed `rc-chat-reminders-vX.Y.Z` format in config
- reduce the chance of stale duplicate release PRs like `#18`

## Testing

- `script/ci`
